### PR TITLE
Make prober pass through request options

### DIFF
--- a/adapters/probing.js
+++ b/adapters/probing.js
@@ -1,5 +1,6 @@
 var globalRequest = require('request');
 var Prober = require('airlock');
+var xtend = require('xtend');
 
 module.exports = ProbingRequestHandler;
 function ProbingRequestHandler(requestHandler, options) {
@@ -19,10 +20,11 @@ function ProbingRequestHandler(requestHandler, options) {
 
 ProbingRequestHandler.prototype.request =
 function handleProbingRequest(request, opts, cb) {
+    opts = xtend(opts, {request: this.options.request});
     var thunk = this.requestHandler.request.bind(
         this.requestHandler,
         request,
-        this.options
+        opts
     );
     this.prober.probe(thunk, cb);
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "jayschema": "^0.3.1",
     "jayschema-error-messages": "^1.0.2",
     "request": "^2.44.0",
-    "uber-json-schema-filter": "^2.0.1"
+    "uber-json-schema-filter": "^2.0.1",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "body": "^4.5.0",


### PR DESCRIPTION
Make the prober adapter pass through the request options, extending with request.