### PR TITLE
do not validate errors

### DIFF
--- a/adapters/validating.js
+++ b/adapters/validating.js
@@ -29,16 +29,23 @@ function handleValidatingRequest(treq, requestOptions, handleResponse) {
         if (error) {
             return handleResponse(error);
         }
-        var result = validateShape(response, responseSchema);
 
-        if (result.type === 'error') {
-            result.error.tres = response;
-            result.error.schema = responseSchema;
+        if (response.statusCode < 400 ||
+            response.statusCode >= 600
+        ) {
+            var result = validateShape(response, responseSchema);
 
-            // TODO make this a better error.
-            return handleResponse(result.error);
+            if (result.type === 'error') {
+                result.error.tres = response;
+                result.error.schema = responseSchema;
+
+                // TODO make this a better error.
+                return handleResponse(result.error);
+            }
+
+            handleResponse(null, result.ok);
+        } else {
+            handleResponse(null, response);
         }
-
-        handleResponse(null, result.ok);
     }
 };


### PR DESCRIPTION
Currently the sirvice client will take an error that comes
back from a remote server. If it does not match the response
validation it will take a 500 and convert it into a response
validation error.

This is completely useful for a person using the client, they
dont care that the server returned a malformed 500, they want
to see the actual 500.

Response validation is a tool that helps the service maintainer
not the people calling the service. It should only be used
in the server, not the client.

reviewers: @jwolski @iproctor @markyen

cc: @rsokol @sh1mmer