### PR TITLE
Sanitize stat strings by removing curlies

### DIFF
--- a/test/write-stats.js
+++ b/test/write-stats.js
@@ -2,44 +2,78 @@ var EventEmitter = require('events').EventEmitter;
 var test = require('tape');
 var writeStats = require('../write-stats.js');
 
+function assertIncrement(assert, testData) {
+    emitStat(testData, {
+        increment: function incrementIt(actual) {
+            assert.equal(actual, testData.statKey);
+        }
+    });
+}
+
+function assertTiming(assert, testData) {
+    emitStat(testData, {
+        timing: function timeIt(actual) {
+            assert.equal(actual, testData.statKey);
+        }
+    });
+}
+
+function createTestData(resource, statKeyPart) {
+    return {
+        makeRequest: {
+            args: [resource],
+            eventName: 'makeRequest',
+            statKey: 'typed-request-client.myclient.' + (statKeyPart || resource) + '.request'
+        },
+        requestTime: {
+            args: [resource, 1],
+            eventName: 'requestTime',
+            statKey: 'typed-request-client.myclient.' + (statKeyPart || resource) + '.request-time'
+        },
+        statusCode: {
+            args: [resource, 200],
+            eventName: 'statusCode',
+            statKey: 'typed-request-client.myclient.' + (statKeyPart || resource) + '.statusCode.200'
+        },
+        totalTime: {
+            args: [resource],
+            eventName: 'totalTime',
+            statKey: 'typed-request-client.myclient.' + (statKeyPart || resource) + '.total-time'
+        }
+    };
+};
+
+function emitStat(testData, statsd) {
+    var emitter = new EventEmitter();
+
+    writeStats(emitter, {
+        clientName: 'myclient',
+        statsd: statsd
+    });
+
+    testData.args.unshift(testData.eventName);
+
+    emitter.emit.apply(emitter, testData.args);
+}
+
 test('writes stats with dots', function t(assert) {
     assert.plan(4);
 
-    function emitStat(eventArgs, statsd) {
-        var emitter = new EventEmitter();
-        var options = {
-            clientName: 'myclient',
-            statsd: statsd
-        };
-        writeStats(emitter, options);
+    var testData = createTestData('myresource');
+    assertIncrement(assert, testData.makeRequest);
+    assertIncrement(assert, testData.statusCode);
+    assertTiming(assert, testData.requestTime);
+    assertTiming(assert, testData.totalTime);
+    assert.end();
+});
 
-        emitter.emit.apply(emitter, eventArgs);
-    }
+test('writes stats without curlies', function t(assert) {
+    assert.plan(4);
 
-    function assertIncrement(eventArgs, expectedStat) {
-        emitStat(eventArgs, {
-            increment: function incrementIt(actual) {
-                assert.equal(actual, expectedStat);
-            }
-        });
-    }
-
-    function assertTiming(eventArgs, expectedStat) {
-        emitStat(eventArgs, {
-            timing: function timeIt(actual) {
-                assert.equal(actual, expectedStat);
-            }
-        });
-    }
-
-    var resource = 'myresource';
-    assertIncrement(['makeRequest', resource],
-        'typed-request-client.myclient.myresource.request');
-    assertTiming(['requestTime', resource, 1],
-        'typed-request-client.myclient.myresource.request-time');
-    assertIncrement(['statusCode', resource, 200],
-        'typed-request-client.myclient.myresource.statusCode.200');
-    assertTiming(['totalTime', resource],
-        'typed-request-client.myclient.myresource.total-time');
+    var testData = createTestData('{myresource}', 'myresource');
+    assertIncrement(assert, testData.makeRequest);
+    assertIncrement(assert, testData.statusCode);
+    assertTiming(assert, testData.requestTime);
+    assertTiming(assert, testData.totalTime);
     assert.end();
 });

--- a/write-stats.js
+++ b/write-stats.js
@@ -9,40 +9,23 @@ function writeStats(emitter, options) {
     emitter.on('statusCode', onStatusCode);
     emitter.on('totalTime', onTotalTime);
 
+    function sanitize(statStr) {
+        return statStr.replace(/{|}/g, '');
+    }
+
     function onMakeRequest(resource) {
-        statsd.increment([
-            'typed-request-client',
-            clientName,
-            resource,
-            'request'
-        ].join('.'));
+        statsd.increment(sanitize('typed-request-client.' + clientName + '.' + resource + '.request'));
     }
 
     function onRequestTime(resource, delta) {
-        statsd.timing([
-            'typed-request-client',
-            clientName,
-            resource,
-            'request-time'
-        ].join('.'), delta);
+        statsd.timing(sanitize('typed-request-client.' + clientName + '.' + resource + '.request-time'), delta);
     }
 
     function onStatusCode(resource, statusCode) {
-        statsd.increment([
-            'typed-request-client',
-            clientName,
-            resource,
-            'statusCode',
-            statusCode
-        ].join('.'));
+        statsd.increment(sanitize('typed-request-client.' + clientName + '.' + resource + '.statusCode.' + statusCode));
     }
 
     function onTotalTime(resource, delta) {
-        statsd.timing([
-            'typed-request-client',
-            clientName,
-            resource,
-            'total-time'
-        ].join('.'), delta);
+        statsd.timing(sanitize('typed-request-client.' + clientName + '.' + resource + '.total-time'), delta);
     }
 }


### PR DESCRIPTION
@Raynos @kriskowal 

including curlies like `{uuid}` in stat key makes Graphite sad.