### PR TITLE
Update client name in prober

### DIFF
--- a/adapters/probing.js
+++ b/adapters/probing.js
@@ -1,15 +1,23 @@
 var globalRequest = require('request');
 var Prober = require('airlock');
 var xtend = require('xtend');
+var errors = require('../errors.js');
 
 module.exports = ProbingRequestHandler;
 function ProbingRequestHandler(requestHandler, options) {
     if (!(this instanceof ProbingRequestHandler)) {
         return new ProbingRequestHandler(requestHandler, options);
     }
+
+    if (typeof options.clientName !== 'string') {
+        throw errors.MissingClientName({
+            optionsStr: JSON.stringify(options)
+        });
+    }
+
     this.prober = options.prober = Prober({
         enabled: true,
-        title: 'typed-request-client',
+        title: 'typed-request-client.' + options.clientName,
         statsd: options.statsd
     });
     // TODO consider moving this one line into a separate layer.

--- a/adapters/statsd.js
+++ b/adapters/statsd.js
@@ -4,6 +4,7 @@ var writeStats = require('../write-stats.js');
 
 module.exports = StatsdRequestHandler;
 function StatsdRequestHandler(requestHandler, options) {
+    /* istanbul ignore if */
     if (typeof options.clientName !== 'string') {
         throw errors.MissingClientName({
             optionsStr: JSON.stringify(options)

--- a/test/write-stats.js
+++ b/test/write-stats.js
@@ -23,25 +23,29 @@ function createTestData(resource, statKeyPart) {
         makeRequest: {
             args: [resource],
             eventName: 'makeRequest',
-            statKey: 'typed-request-client.myclient.' + (statKeyPart || resource) + '.request'
+            statKey: 'typed-request-client.myclient.' +
+                (statKeyPart || resource) + '.request'
         },
         requestTime: {
             args: [resource, 1],
             eventName: 'requestTime',
-            statKey: 'typed-request-client.myclient.' + (statKeyPart || resource) + '.request-time'
+            statKey: 'typed-request-client.myclient.' +
+                (statKeyPart || resource) + '.request-time'
         },
         statusCode: {
             args: [resource, 200],
             eventName: 'statusCode',
-            statKey: 'typed-request-client.myclient.' + (statKeyPart || resource) + '.statusCode.200'
+            statKey: 'typed-request-client.myclient.' +
+                (statKeyPart || resource) + '.statusCode.200'
         },
         totalTime: {
             args: [resource],
             eventName: 'totalTime',
-            statKey: 'typed-request-client.myclient.' + (statKeyPart || resource) + '.total-time'
+            statKey: 'typed-request-client.myclient.' +
+                (statKeyPart || resource) + '.total-time'
         }
     };
-};
+}
 
 function emitStat(testData, statsd) {
     var emitter = new EventEmitter();

--- a/write-stats.js
+++ b/write-stats.js
@@ -14,18 +14,22 @@ function writeStats(emitter, options) {
     }
 
     function onMakeRequest(resource) {
-        statsd.increment(sanitize('typed-request-client.' + clientName + '.' + resource + '.request'));
+        statsd.increment(sanitize('typed-request-client.' + clientName +
+            '.' + resource + '.request'));
     }
 
     function onRequestTime(resource, delta) {
-        statsd.timing(sanitize('typed-request-client.' + clientName + '.' + resource + '.request-time'), delta);
+        statsd.timing(sanitize('typed-request-client.' + clientName +
+            '.' + resource + '.request-time'), delta);
     }
 
     function onStatusCode(resource, statusCode) {
-        statsd.increment(sanitize('typed-request-client.' + clientName + '.' + resource + '.statusCode.' + statusCode));
+        statsd.increment(sanitize('typed-request-client.' + clientName +
+            '.' + resource + '.statusCode.' + statusCode));
     }
 
     function onTotalTime(resource, delta) {
-        statsd.timing(sanitize('typed-request-client.' + clientName + '.' + resource + '.total-time'), delta);
+        statsd.timing(sanitize('typed-request-client.' + clientName +
+            '.' + resource + '.total-time'), delta);
     }
 }


### PR DESCRIPTION
Use "options.clientName" as part of the prober title, so prober statsd of different clients do not collide with each other. 