### PR TITLE
[typed-request-client] avoid stringify comma from query string

### DIFF
--- a/make-typed-request.js
+++ b/make-typed-request.js
@@ -11,7 +11,8 @@ function makeTypedRequest(treq, opts, cb) {
         url: treq.url,
         method: treq.method || 'GET',
         headers: treq.headers || {},
-        timeout: opts.timeout || DEFUALT_TIMEOUT
+        timeout: opts.timeout || DEFUALT_TIMEOUT,
+        transformUrlFn: opts.transformUrlFn || undefined
     };
 
     if (treq.body !== undefined) {
@@ -25,6 +26,10 @@ function makeTypedRequest(treq, opts, cb) {
             querystring.stringify(treq.query);
     }
 
+    if (typeof reqOpts.transformUrlFn === 'function') {
+        reqOpts.url = reqOpts.transformUrlFn(reqOpts.url);
+    }
+
     request(reqOpts, onResponse);
 
     function onResponse(err, resp) {
@@ -36,7 +41,8 @@ function makeTypedRequest(treq, opts, cb) {
             httpVersion: resp.httpVersion,
             headers: resp.headers,
             statusCode: resp.statusCode,
-            body: resp.body
+            body: resp.body,
+            requestUrl: reqOpts.url
         };
 
         cb(null, tres);

--- a/test/integration.js
+++ b/test/integration.js
@@ -136,7 +136,7 @@ test('passes 500 right through', function t(assert) {
             // assert.deepEqual(tres.headers, {});
             assert.deepEqual(tres.body, { message: 'sad' });
             assert.deepEqual(Object.keys(tres), [
-                 'httpVersion', 'headers', 'statusCode', 'body'
+                 'httpVersion', 'headers', 'statusCode', 'body', 'requestUrl'
             ]);
 
             server.close();

--- a/test/typed-request-client.js
+++ b/test/typed-request-client.js
@@ -61,7 +61,7 @@ test('can make request', function t(assert) {
             });
 
             assert.deepEqual(Object.keys(opts), [
-                'url', 'method', 'headers', 'timeout', 'json'
+                'url', 'method', 'headers', 'timeout', 'transformUrlFn', 'json'
             ]);
 
             cb(null, {


### PR DESCRIPTION
Currently queries like { prop: ['1,2', '3,4'] } is being stringify'ed as '?prop=1%2C2&prop=3%2C4'. The resulting string cannot be parsed by services like OSRM (https://github.com/Project-OSRM/osrm-backend/wiki/Server-api). This change allows callsites to pass a callback function as part of the request options, and revert the stringify for commas.

Also added a unit test to cover the change.