### PR TITLE
[typed-request-client] avoid stringify comma from query string

### DIFF
--- a/make-typed-request.js
+++ b/make-typed-request.js
@@ -11,7 +11,8 @@ function makeTypedRequest(treq, opts, cb) {
         url: treq.url,
         method: treq.method || 'GET',
         headers: treq.headers || {},
-        timeout: opts.timeout || DEFUALT_TIMEOUT
+        timeout: opts.timeout || DEFUALT_TIMEOUT,
+        transformUrlFn: opts.transformUrlFn || undefined
     };
 
     if (treq.body !== undefined) {
@@ -23,6 +24,10 @@ function makeTypedRequest(treq, opts, cb) {
     if (treq.query) {
         reqOpts.url = reqOpts.url + '?' +
             querystring.stringify(treq.query);
+    }
+
+    if (typeof reqOpts.transformUrlFn === 'function') {
+        reqOpts.url = reqOpts.transformUrlFn(reqOpts.url);
     }
 
     request(reqOpts, onResponse);

--- a/test/typed-request-client.js
+++ b/test/typed-request-client.js
@@ -61,7 +61,7 @@ test('can make request', function t(assert) {
             });
 
             assert.deepEqual(Object.keys(opts), [
-                'url', 'method', 'headers', 'timeout', 'json'
+                'url', 'method', 'headers', 'timeout', 'transformUrlFn', 'json'
             ]);
 
             cb(null, {


### PR DESCRIPTION
Currently queries like { prop: ['1,2', '3,4'] } is being stringify'ed as
'?prop=1%2C2&prop=3%2C4'. The resulting string cannot be parsed by
services like OSRM
(https://github.com/Project-OSRM/osrm-backend/wiki/Server-api). This
change allows callsites to pass a callback function as part of the
request options, and revert the stringify for commas.

Also added a unit test to cover the change.