### PR TITLE
Do not add `?` in case query submitted is empty

### DIFF
--- a/make-typed-request.js
+++ b/make-typed-request.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var _ = require('underscore');
 var querystring = require('querystring');
 var xtend = require('xtend');
 
@@ -28,7 +29,7 @@ function makeTypedRequest(treq, opts, cb) {
         reqOpts.json = true;
     }
 
-    if (treq.query) {
+    if (treq.query && !_.isEmpty(treq.query)) {
         reqOpts.url = reqOpts.url + '?' +
             querystring.stringify(treq.query);
     }

--- a/make-typed-request.js
+++ b/make-typed-request.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('underscore');
 var querystring = require('querystring');
 var xtend = require('xtend');
 
@@ -29,9 +28,11 @@ function makeTypedRequest(treq, opts, cb) {
         reqOpts.json = true;
     }
 
-    if (treq.query && !_.isEmpty(treq.query)) {
-        reqOpts.url = reqOpts.url + '?' +
-            querystring.stringify(treq.query);
+    if (treq.query) {
+        var query = querystring.stringify(treq.query);
+        if (query !== '') {
+            reqOpts.url = reqOpts.url + '?' + query;
+        }
     }
 
     if (typeof reqOpts.transformUrlFn === 'function') {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "jayschema-error-messages": "^1.0.2",
     "request": "^2.44.0",
     "uber-json-schema-filter": "^2.0.3",
-    "xtend": "^4.0.0",
-    "underscore": "^1.8.3"
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "body": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "jayschema-error-messages": "^1.0.2",
     "request": "^2.44.0",
     "uber-json-schema-filter": "^2.0.3",
-    "xtend": "^4.0.0"
+    "xtend": "^4.0.0",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "body": "^4.5.0",

--- a/test/make-typed-request.js
+++ b/test/make-typed-request.js
@@ -113,7 +113,7 @@ test('request with POST', function t(assert) {
     });
 });
 
-test('request with GET', function t(assert) {
+test('request with GET w/ query', function t(assert) {
     var server = createServer(function onPort(port) {
         var treq = {
             method: 'GET',
@@ -134,6 +134,36 @@ test('request with GET', function t(assert) {
             assert.deepEqual(resp.body, {
                 method: 'GET',
                 url: '/?hello=world',
+                req: {}
+            });
+
+            server.close();
+            assert.end();
+        }
+    });
+});
+
+test('request with GET w/o query', function t(assert) {
+    var server = createServer(function onPort(port) {
+        var treq = {
+            method: 'GET',
+            url: 'http://localhost:' + port + '/',
+            query: {},
+            body: {}
+        };
+
+        makeTypedRequest(treq, reqOpts, onResponse);
+
+        function onResponse(err, resp) {
+            assert.ifError(err);
+
+            assert.equal(resp.httpVersion, '1.1');
+            assert.ok(resp.headers);
+            assert.equal(resp.headers['content-type'],
+                'application/json');
+            assert.deepEqual(resp.body, {
+                method: 'GET',
+                url: '/',
                 req: {}
             });
 


### PR DESCRIPTION
This recently started to break RTAPI integration tests. 

And just out of common sense.